### PR TITLE
Update for HackRF blue and RTL-SDR

### DIFF
--- a/README
+++ b/README
@@ -3,9 +3,10 @@ Transmits a ukhasnet-style packet on 869.500 MHz from a HackRF.
 
 Usage: ukhasnet_tx "packet content"
 
-Test reception with RTL-SDR:
+Test reception with RTL-SDR
+https://github.com/UKHASnet/UKHASnet-decoder
 
-rtl_fm -f 869500000 -s 64k -g 48 -p 162 | UKHASnet-decoder/UKHASnet-decoder -v -s 64000
+rtl_fm -f 869500000 -s 64k -g 48 -p 162 | UKHASnet-decoder -v -s 64000
 
 If it receives wrong sync D255 instead of 2DAA
 then all bits in packet have to be inverted

--- a/README
+++ b/README
@@ -3,5 +3,10 @@ Transmits a ukhasnet-style packet on 869.500 MHz from a HackRF.
 
 Usage: ukhasnet_tx "packet content"
 
+Test reception with RTL-SDR:
+
+rtl_fm -f 869500000 -s 64k -g 48 -p 162 | UKHASnet-decoder/UKHASnet-decoder -v -s 64000
+
 -Philip Heron <phil@sanslogic.co.uk>
 
+-EMARD (fixed to work for my hackrf blue)

--- a/README
+++ b/README
@@ -7,6 +7,11 @@ Test reception with RTL-SDR:
 
 rtl_fm -f 869500000 -s 64k -g 48 -p 162 | UKHASnet-decoder/UKHASnet-decoder -v -s 64000
 
+If it receives wrong sync D255 instead of 2DAA
+then all bits in packet have to be inverted
+
+#define INVERT_BITS  (1)
+
 -Philip Heron <phil@sanslogic.co.uk>
 
 -EMARD (fixed to work for my hackrf blue)

--- a/ukhasnet_tx.c
+++ b/ukhasnet_tx.c
@@ -21,6 +21,7 @@
 #define FSTEP      (2 * M_PI * DEVIATION / SAMPLERATE)
 
 /* Packet details */
+#define INVERT_BITS  (0)           /* 0-send normal, 1-send inverted */
 #define PREAMBLE_SYM (0xAA)
 #define PREAMBLE_LEN (3)
 #define SYNC_WORD    (0x2DAA)
@@ -143,7 +144,11 @@ void ukhasnet_packet(void *data, size_t length)
 					fi = cos(ph);
 					fq = sin(ph);
 					
+					#if INVERT_BITS
 					ph += (bit ? -FSTEP : FSTEP);
+					#else
+					ph += (bit ? FSTEP : -FSTEP);
+					#endif
 					
 					fi = _fir(FIR_LEN, _fir_co, fih, fi);
 					fq = _fir(FIR_LEN, _fir_co, fqh, fq);


### PR DESCRIPTION
HI

I have HackRF blue and RTL-SDR dvb-t usb stick.
Transmitter has to add short silence before and after packet
and RTL-SDR receives that for first few minutes until RTL-SDR warms
up, then packets are received will all bits inverted.

Probably it's a problem in RTL-SDR, who knows, 
because even warm RTL-SDR normally receives other 
(non-hackrf) transmitters.

So I added compile-time parameter in hackrf transmitter to invert all bits
in the packet so it can reach either cold or warm RTL-SDR.

Also there's some README update too

Davor
